### PR TITLE
run specs against postgresql 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+addons:
+  postgresql: '9.4'
+
 before_script:
   - curl --silent -L https://gist.githubusercontent.com/BM5k/38c55d9ffaf6f9865949/raw/database.yml -o config/database.yml
   - bundle exec rake db:setup


### PR DESCRIPTION
I’ve also upgraded our staging database from 9.3.4 to 9.4.0. If everybody’s happy, we can move from 9.3.5 to 9.4.0 in production, too

## ci
- [x] update travis
