### PR TITLE
Vagrantfile added

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   # Box config
   config.vm.box = 'mtchavez/rails-dev'
-  config.vm.box_version = '>= 0.0.2'
+  config.vm.box_version = '>= 0.0.3'
 
   # Set up network
   config.vm.network 'private_network', ip: '192.168.33.10'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  # Box config
+  config.vm.box = 'mtchavez/rails-dev'
+  config.vm.box_version = '>= 0.0.2'
+
+  # Set up network
+  config.vm.network 'private_network', ip: '192.168.33.10'
+  config.vm.network 'forwarded_port', guest: 5000, host: 5000
+  config.vm.hostname = 'meeples-dev'
+
+  # Sync app to VM
+  config.vm.synced_folder '.', '/srv/app', type: 'nfs'
+
+  # Virtualbox VM config
+  config.vm.provider 'virtualbox' do |vb|
+    vb.name = 'meeples'
+    vb.memory = '4096'
+    vb.cpus = 2
+    opts = ['modifyvm', :id, '--natdnshostresolver1', 'on']
+    vb.customize opts
+  end
+end


### PR DESCRIPTION
Vagrant setup to fix #72 

## Pre-requisites

* Virtualbox `>= 4.3.20`
* Vagrant `>= 1.7.2`

## Using

* After you have set up Virutalbox and Vagrant you should just need to do `vagrant up`
* Use `vagrant ssh` to get into the VM, which will put you into the app directory
* The box has RVM and bundler so installing dependencies should be the same
* Run app with `bundle exec foreman start` and visit on host `192.168.33.10:5000`

## Gotchas

* We are using NFS which may ask you to enter your sudo password on the host box
* If it asks you for the `vagrant` user password this is `vagrant`