### PR TITLE
add heroku app manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ rake spec # this will run all of the RSpec specifications, located in ./spec
 
 Recommended deployment is via [Heroku](http://heroku.com). They have an excellent intro at http://docs.heroku.com/quickstart
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ### Addons
 
 We're using the following heroku addons

--- a/app.json
+++ b/app.json
@@ -1,0 +1,52 @@
+{
+  "name": "Meepl.es",
+  "description": "Track your favorite games!",
+  "repository": "https://github.com/meeples/meeples",
+  "keywords": [
+    "devise",
+    "heroku",
+    "rails"
+  ],
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "memcachier:dev",
+    "newrelic:stark",
+    "papertrail:choklad",
+    "pgbackups:plus",
+    "rollbar:free",
+    "sendgrid:starter"
+  ],
+  "env": {
+    "EMAIL_HOST": {
+      "description": "The hostname used in outgoing emails.",
+      "required": false
+    },
+    "FACEBOOK_APP_ID": {
+      "description": "App id from Facebook",
+      "required": false
+    },
+    "FACEBOOK_SECRET": {
+      "description": "App secret from Facebook",
+      "required": false
+    },
+    "GITHUB_APP_ID": {
+      "description": "App id from Github",
+      "required": false
+    },
+    "GITHUB_SECRET": {
+      "description": "App secret from Github",
+      "required": false
+    },
+    "SECRET_TOKEN": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    },
+    "UNICORN_WORKERS": {
+      "description": "Number of unicorn workers to start (default: 3)",
+      "generator": "3"
+    }
+  },
+  "scripts": {
+    "postdeploy": "bundle exec rake bootstrap"
+  }
+}


### PR DESCRIPTION
Details how to host the app on heroku. We can then move production/staging config info out of the README and into something actionable.

- [x] app.json
- [x] add deploy to heroku button to the readme